### PR TITLE
Feature: paste from clipboard button in URL View

### DIFF
--- a/Loadify/View/Components/CustomTextField.swift
+++ b/Loadify/View/Components/CustomTextField.swift
@@ -13,10 +13,12 @@ struct CustomTextField: View {
     @Binding var text: String
     
     var placeHolder: String
+    var onPaste: () -> Void // Add a closure to handle paste action
     
-    init(_ placeHolder: String, text: Binding<String>) {
+    init(_ placeHolder: String, text: Binding<String>, onPaste: @escaping () -> Void) {
         self.placeHolder = placeHolder
         self._text = text
+        self.onPaste = onPaste // Initialize the closure
     }
     
     var body: some View {
@@ -36,8 +38,14 @@ struct CustomTextField: View {
                         
                     }.padding(.leading, 16)
                 }
-                
-                if !text.isEmpty {
+                if text.isEmpty {
+                    Button(action: onPaste, label: { // Use the onPaste closure here
+                        Image(systemName: "doc.on.clipboard") // Use the appropriate system image for paste
+                            .frame(maxHeight: .infinity)
+                            .padding(.horizontal, 10)
+                            .foregroundStyle(.white)
+                    })
+                } else {
                     Button(action: didTapClearIcon, label: {
                         Image(systemName: "xmark.circle.fill")
                             .frame(maxHeight: .infinity)
@@ -67,7 +75,7 @@ struct CustomTextField: View {
 struct CustomTextField_Previews: PreviewProvider {
     
     static var previews: some View {
-        CustomTextField("Enter YouTube or Instagram URL", text: .constant(""))
+        CustomTextField("Enter YouTube or Instagram URL", text: .constant(""), onPaste: {})
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Loadify/View/Components/CustomTextField.swift
+++ b/Loadify/View/Components/CustomTextField.swift
@@ -13,12 +13,9 @@ struct CustomTextField: View {
     @Binding var text: String
     
     var placeHolder: String
-    var onPaste: () -> Void // Add a closure to handle paste action
-    
-    init(_ placeHolder: String, text: Binding<String>, onPaste: @escaping () -> Void) {
+    init(_ placeHolder: String, text: Binding<String>) {
         self.placeHolder = placeHolder
         self._text = text
-        self.onPaste = onPaste // Initialize the closure
     }
     
     var body: some View {
@@ -39,7 +36,7 @@ struct CustomTextField: View {
                     }.padding(.leading, 16)
                 }
                 if text.isEmpty {
-                    Button(action: onPaste, label: { // Use the onPaste closure here
+                    Button(action: didTapOnPasteIcon, label: {
                         Image(systemName: "doc.on.clipboard") // Use the appropriate system image for paste
                             .frame(maxHeight: .infinity)
                             .padding(.horizontal, 10)
@@ -70,12 +67,16 @@ struct CustomTextField: View {
     private func didTapClearIcon() {
         text.removeAll()
     }
+
+    private func didTapOnPasteIcon() {
+        text = UIPasteboard.general.string ?? ""
+    }
 }
 
 struct CustomTextField_Previews: PreviewProvider {
     
     static var previews: some View {
-        CustomTextField("Enter YouTube or Instagram URL", text: .constant(""), onPaste: {})
+        CustomTextField("Enter YouTube or Instagram URL", text: .constant(""))
             .previewLayout(.sizeThatFits)
     }
 }

--- a/Loadify/View/URLView.swift
+++ b/Loadify/View/URLView.swift
@@ -61,9 +61,7 @@ struct URLView: View {
     
     private var textFieldView: some View {
         VStack(spacing: 12) {
-            CustomTextField("Enter YouTube or Instagram URL", text: $videoURL, onPaste: {
-                self.videoURL = UIPasteboard.general.string ?? ""
-            })
+            CustomTextField("Enter YouTube or Instagram URL", text: $videoURL)
             NavigationLink(
                 destination: downloaderView,
                 isActive: $viewModel.shouldNavigateToDownload

--- a/Loadify/View/URLView.swift
+++ b/Loadify/View/URLView.swift
@@ -61,18 +61,22 @@ struct URLView: View {
     
     private var textFieldView: some View {
         VStack(spacing: 12) {
-            CustomTextField("Enter YouTube or Instagram URL", text: $videoURL)
-            
-            NavigationLink(
-                destination: downloaderView,
-                isActive: $viewModel.shouldNavigateToDownload
-            ) {
-                DownloadButton("Convert", isDisabled: isConvertButtonDisabled) {
-                    Task {
-                        await didTapContinue()
-                    }
+                CustomTextField("Enter YouTube or Instagram URL", text: $videoURL)
+                Button(action: {
+                    self.videoURL = UIPasteboard.general.string ?? ""
+                }) {
+                    Text("Paste from Clipboard")
                 }
-            }.disabled(isConvertButtonDisabled)
+                NavigationLink(
+                    destination: downloaderView,
+                    isActive: $viewModel.shouldNavigateToDownload
+                ) {
+                    DownloadButton("Convert", isDisabled: isConvertButtonDisabled) {
+                        Task {
+                            await didTapContinue()
+                        }
+                    }
+                }.disabled(isConvertButtonDisabled)
         }
     }
     

--- a/Loadify/View/URLView.swift
+++ b/Loadify/View/URLView.swift
@@ -61,22 +61,19 @@ struct URLView: View {
     
     private var textFieldView: some View {
         VStack(spacing: 12) {
-                CustomTextField("Enter YouTube or Instagram URL", text: $videoURL)
-                Button(action: {
-                    self.videoURL = UIPasteboard.general.string ?? ""
-                }) {
-                    Text("Paste from Clipboard")
-                }
-                NavigationLink(
-                    destination: downloaderView,
-                    isActive: $viewModel.shouldNavigateToDownload
-                ) {
-                    DownloadButton("Convert", isDisabled: isConvertButtonDisabled) {
-                        Task {
-                            await didTapContinue()
-                        }
+            CustomTextField("Enter YouTube or Instagram URL", text: $videoURL, onPaste: {
+                self.videoURL = UIPasteboard.general.string ?? ""
+            })
+            NavigationLink(
+                destination: downloaderView,
+                isActive: $viewModel.shouldNavigateToDownload
+            ) {
+                DownloadButton("Convert", isDisabled: isConvertButtonDisabled) {
+                    Task {
+                        await didTapContinue()
                     }
-                }.disabled(isConvertButtonDisabled)
+                }
+            }.disabled(isConvertButtonDisabled)
         }
     }
     


### PR DESCRIPTION
# Description 

Implemented a paste from clipboard button in the URLView to make it easier to add URLs. 


# Screenshots

| Before | After |
|:------:|:------:|
| <img src="https://github.com/VishwaiOSDev/Loadify-iOS/assets/32654532/2287e2e2-255c-4493-b9d5-0b7e74f4be77" width="400" style="margin-bottom: 10px;"> | <img src="https://github.com/VishwaiOSDev/Loadify-iOS/assets/32654532/298e1308-bc09-4e6d-95ac-b69d3fbc5e3d" width="350" style="margin-bottom: 10px;"> |

# Notes to Reviewers 

I was using this on my own and thought it would be more convenient to add a button to paste from the clipboard instead of holding down the text field box and waiting for the paste option to come up. Let me know if this makes it easier for anyone else. I enjoyed using your app @VishwaiOSDev ! 